### PR TITLE
Added environment variable to specify remote maven agent address

### DIFF
--- a/maven-agent/src/main/java/hudson/maven/agent/Main.java
+++ b/maven-agent/src/main/java/hudson/maven/agent/Main.java
@@ -127,18 +127,7 @@ public class Main {
         remoting.setParent(launcher.getWorld().getRealm("plexus.core.maven"));
         remoting.addConstituent(remotingJar.toURI().toURL());
 	
-	final Socket s; 
-    String mavenRemoteUseInetEnvVar = System.getenv( "MAVEN_REMOTE_USEINET" );
-
-    boolean mavenRemoteUseInet = Boolean.parseBoolean( mavenRemoteUseInetEnvVar );
-	if(mavenRemoteUseInet) {
-		InetAddress host = InetAddress.getLocalHost();
-        String hostname = host.getHostName();
-        System.out.println( "use inet address " + hostname );
-		s = new Socket(hostname,tcpPort);
-	}
-	else 
-		s = new Socket((String)null,tcpPort);
+        final Socket s = new Socket(getAgentHostname(),tcpPort);
 
         Class remotingLauncher = remoting.loadClass("hudson.remoting.Launcher");
         remotingLauncher.getMethod("main",new Class[]{InputStream.class,OutputStream.class}).invoke(null,
@@ -156,6 +145,31 @@ public class Main {
                         })
                 });
         System.exit(0);
+    }
+
+    private static String getAgentHostname() throws IOException {
+        String mavenRemoteUseInetEnvVar = System.getenv( "MAVEN_REMOTE_USEINET" );
+        boolean mavenRemoteUseInet = Boolean.parseBoolean( mavenRemoteUseInetEnvVar );
+
+        if(mavenRemoteUseInet) {
+            InetAddress host = InetAddress.getLocalHost();
+            String hostname = host.getHostName();
+            System.out.println( "use inet address " + hostname );
+            return hostname;
+        }
+
+        String mavenAgentAddress = System.getenv( "MAVEN_REMOTE_ADDRESS" );
+
+        if(mavenAgentAddress != null) {
+            mavenAgentAddress = mavenAgentAddress.trim();
+
+            if(mavenAgentAddress.length() > 0) {
+                System.out.println( "use agent address " + mavenAgentAddress );
+                return mavenAgentAddress;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/maven3-agent/src/main/java/org/jvnet/hudson/maven3/agent/Maven3Main.java
+++ b/maven3-agent/src/main/java/org/jvnet/hudson/maven3/agent/Maven3Main.java
@@ -117,20 +117,7 @@ public class Maven3Main {
         remoting.setParentRealm(launcher.getWorld().getRealm("plexus.core"));
         remoting.addURL(remotingJar.toURI().toURL());
 
-	    final Socket s;
-
-        String mavenRemoteUseInetEnvVar = System.getenv( "MAVEN_REMOTE_USEINET" );
-
-        boolean mavenRemoteUseInet = Boolean.parseBoolean( mavenRemoteUseInetEnvVar );
-
-        if(mavenRemoteUseInet) {
-            InetAddress host = InetAddress.getLocalHost();
-            String hostname = host.getHostName();
-            System.out.println( "use inet address " + hostname );
-            s = new Socket(hostname,tcpPort);
-        }
-        else
-            s = new Socket((String)null,tcpPort);
+        final Socket s = new Socket(getAgentHostname(),tcpPort);
 
         Class remotingLauncher = remoting.loadClass("hudson.remoting.Launcher");
         remotingLauncher.getMethod("main",
@@ -153,6 +140,31 @@ public class Maven3Main {
                         }) });
         System.exit(0);
 	}
+
+    private static String getAgentHostname() throws IOException {
+        String mavenRemoteUseInetEnvVar = System.getenv( "MAVEN_REMOTE_USEINET" );
+        boolean mavenRemoteUseInet = Boolean.parseBoolean( mavenRemoteUseInetEnvVar );
+
+        if(mavenRemoteUseInet) {
+            InetAddress host = InetAddress.getLocalHost();
+            String hostname = host.getHostName();
+            System.out.println( "use inet address " + hostname );
+            return hostname;
+        }
+
+        String mavenAgentAddress = System.getenv( "MAVEN_REMOTE_ADDRESS" );
+
+        if(mavenAgentAddress != null) {
+            mavenAgentAddress = mavenAgentAddress.trim();
+
+            if(mavenAgentAddress.length() > 0) {
+                System.out.println( "use agent address " + mavenAgentAddress );
+                return mavenAgentAddress;
+            }
+        }
+
+        return null;
+    }
 
     /**
      * Called by the code in remoting to add more plexus components.

--- a/maven31-agent/src/main/java/jenkins/maven3/agent/Maven31Main.java
+++ b/maven31-agent/src/main/java/jenkins/maven3/agent/Maven31Main.java
@@ -120,20 +120,7 @@ public class Maven31Main
         remoting.setParentRealm(launcher.getWorld().getRealm("plexus.core"));
         remoting.addURL(remotingJar.toURI().toURL());
 
-	    final Socket s;
-
-        String mavenRemoteUseInetEnvVar = System.getenv( "MAVEN_REMOTE_USEINET" );
-
-        boolean mavenRemoteUseInet = Boolean.parseBoolean( mavenRemoteUseInetEnvVar );
-
-        if(mavenRemoteUseInet) {
-            InetAddress host = InetAddress.getLocalHost();
-            String hostname = host.getHostName();
-            System.out.println( "use inet address " + hostname );
-            s = new Socket(hostname,tcpPort);
-        }
-        else
-            s = new Socket((String)null,tcpPort);
+        final Socket s = new Socket(getAgentHostname(),tcpPort);
 
         Class remotingLauncher = remoting.loadClass("hudson.remoting.Launcher");
         remotingLauncher.getMethod("main",
@@ -156,6 +143,31 @@ public class Maven31Main
                         }) });
         System.exit(0);
 	}
+
+    private static String getAgentHostname() throws IOException {
+        String mavenRemoteUseInetEnvVar = System.getenv( "MAVEN_REMOTE_USEINET" );
+        boolean mavenRemoteUseInet = Boolean.parseBoolean( mavenRemoteUseInetEnvVar );
+
+        if(mavenRemoteUseInet) {
+            InetAddress host = InetAddress.getLocalHost();
+            String hostname = host.getHostName();
+            System.out.println( "use inet address " + hostname );
+            return hostname;
+        }
+
+        String mavenAgentAddress = System.getenv( "MAVEN_REMOTE_ADDRESS" );
+
+        if(mavenAgentAddress != null) {
+            mavenAgentAddress = mavenAgentAddress.trim();
+
+            if(mavenAgentAddress.length() > 0) {
+                System.out.println( "use agent address " + mavenAgentAddress );
+                return mavenAgentAddress;
+            }
+        }
+
+        return null;
+    }
 
     /**
      * Called by the code in remoting to add more plexus components.


### PR DESCRIPTION
I am working on a plugin to run jobs in a docker container. This change is necessary to run maven builds in the container since loopback and the local hostname will refer to the container rather than the host system where the jenkins agent service is running.
