### PR TITLE
Fix NPE when executing parallel module builds

### DIFF
--- a/maven-agent/src/main/java/hudson/maven/agent/Main.java
+++ b/maven-agent/src/main/java/hudson/maven/agent/Main.java
@@ -43,8 +43,8 @@ import org.codehaus.classworlds.ClassWorld;
 import org.codehaus.classworlds.DefaultClassRealm;
 import org.codehaus.classworlds.Launcher;
 import org.codehaus.classworlds.NoSuchRealmException;
-import org.codehaus.plexus.classworlds.realm.DuplicateRealmException;
-import org.codehaus.plexus.classworlds.launcher.ConfigurationException;
+import org.codehaus.classworlds.DuplicateRealmException;
+import org.codehaus.classworlds.ConfigurationException;
 
 /**
  * Entry point for launching Maven and Hudson remoting in the same VM,

--- a/maven-agent/src/main/java/hudson/maven/agent/Main.java
+++ b/maven-agent/src/main/java/hudson/maven/agent/Main.java
@@ -202,7 +202,9 @@ public class Main {
     /**
      * Called by the code in remoting to launch.
      */
-    public static int launch(String[] args) throws NoSuchMethodException, IllegalAccessException, NoSuchRealmException, InvocationTargetException, ClassNotFoundException {
+    public static int launch(String[] args)
+        throws NoSuchMethodException, IllegalAccessException, NoSuchRealmException, DuplicateRealmException,
+                IOException, InvocationTargetException, ClassNotFoundException, ConfigurationException {
         //ClassWorld world = ClassWorldAdapter.getInstance( launcher.getWorld() );
         if (launcher == null) {
             initializeLauncher();

--- a/maven3-agent/src/main/java/org/jvnet/hudson/maven3/agent/Maven3Main.java
+++ b/maven3-agent/src/main/java/org/jvnet/hudson/maven3/agent/Maven3Main.java
@@ -26,6 +26,8 @@ package org.jvnet.hudson.maven3.agent;
 import org.codehaus.plexus.classworlds.launcher.Launcher;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
+import org.codehaus.plexus.classworlds.realm.DuplicateRealmException;
+import org.codehaus.plexus.classworlds.launcher.ConfigurationException;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -78,6 +80,14 @@ public class Maven3Main {
 
         main(m2Home, remotingJar, interceptorJar, interceptorCommonJar, null, tcpPort);
     }
+    
+    private static void initializeLauncher()
+	    throws IOException, ConfigurationException, DuplicateRealmException, NoSuchRealmException {
+        // load the default realms
+        launcher = new Launcher();
+        launcher.setSystemClassLoader(Maven32Main.class.getClassLoader());
+        launcher.configure(getClassWorldsConfStream());
+    }
 
     /**
      *
@@ -120,12 +130,8 @@ public class Maven3Main {
             : interceptorCommonJar).getPath());
         System.setProperty("maven3.interceptor", (interceptorJar != null ? interceptorJar
                 : interceptorJar).getPath());
-
-        // load the default realms
-        launcher = new Launcher();
-        launcher.setSystemClassLoader(Maven3Main.class.getClassLoader());
-        launcher.configure(getClassWorldsConfStream());
-
+        
+        initializeLauncher()
 
         // create a realm for loading remoting subsystem.
         // this needs to be able to see maven.
@@ -178,6 +184,10 @@ public class Maven3Main {
     public static int launch( String[] args ) throws Exception {
 
         try {
+            if (launcher == null) {
+                initializeLauncher();
+            }
+
             launcher.launch( args );
         } catch ( Throwable e ) {
             e.printStackTrace();

--- a/maven3-agent/src/main/java/org/jvnet/hudson/maven3/agent/Maven3Main.java
+++ b/maven3-agent/src/main/java/org/jvnet/hudson/maven3/agent/Maven3Main.java
@@ -131,7 +131,7 @@ public class Maven3Main {
         System.setProperty("maven3.interceptor", (interceptorJar != null ? interceptorJar
                 : interceptorJar).getPath());
         
-        initializeLauncher()
+        initializeLauncher();
 
         // create a realm for loading remoting subsystem.
         // this needs to be able to see maven.

--- a/maven3-agent/src/main/java/org/jvnet/hudson/maven3/agent/Maven3Main.java
+++ b/maven3-agent/src/main/java/org/jvnet/hudson/maven3/agent/Maven3Main.java
@@ -85,7 +85,7 @@ public class Maven3Main {
 	    throws IOException, ConfigurationException, DuplicateRealmException, NoSuchRealmException {
         // load the default realms
         launcher = new Launcher();
-        launcher.setSystemClassLoader(Maven32Main.class.getClassLoader());
+        launcher.setSystemClassLoader(Maven3Main.class.getClassLoader());
         launcher.configure(getClassWorldsConfStream());
     }
 

--- a/maven31-agent/src/main/java/jenkins/maven3/agent/Maven31Main.java
+++ b/maven31-agent/src/main/java/jenkins/maven3/agent/Maven31Main.java
@@ -26,6 +26,8 @@ package jenkins.maven3.agent;
 import org.codehaus.plexus.classworlds.launcher.Launcher;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
+import org.codehaus.plexus.classworlds.realm.DuplicateRealmException;
+import org.codehaus.plexus.classworlds.launcher.ConfigurationException;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -82,7 +84,14 @@ public class Maven31Main
         main(m2Home, remotingJar, interceptorJar, interceptorCommonJar, null, tcpPort);
     }
 
-
+    private static void initializeLauncher()
+	    throws IOException, ConfigurationException, DuplicateRealmException, NoSuchRealmException {
+        // load the default realms
+        launcher = new Launcher();
+        launcher.setSystemClassLoader(Maven32Main.class.getClassLoader());
+        launcher.configure(getClassWorldsConfStream());
+    }
+    
     /**
      *
      * @param m2Home
@@ -125,11 +134,7 @@ public class Maven31Main
         System.setProperty("maven3.interceptor", (interceptorJar != null ? interceptorJar
                 : interceptorJar).getPath());
 
-        // load the default realms
-        launcher = new Launcher();
-        launcher.setSystemClassLoader(Maven31Main.class.getClassLoader());
-        launcher.configure(getClassWorldsConfStream());
-
+	    initializeLauncher();
 
         // create a realm for loading remoting subsystem.
         // this needs to be able to see maven.
@@ -175,13 +180,17 @@ public class Maven31Main
             throw new Error(e);
         }
     }
-
+    
     /**
      * Called by the code in remoting to launch.
      */
     public static int launch( String[] args ) throws Exception {
 
         try {
+            if (launcher == null) {
+                initializeLauncher();
+            }
+
             launcher.launch( args );
         } catch ( Throwable e ) {
             e.printStackTrace();

--- a/maven31-agent/src/main/java/jenkins/maven3/agent/Maven31Main.java
+++ b/maven31-agent/src/main/java/jenkins/maven3/agent/Maven31Main.java
@@ -88,7 +88,7 @@ public class Maven31Main
 	    throws IOException, ConfigurationException, DuplicateRealmException, NoSuchRealmException {
         // load the default realms
         launcher = new Launcher();
-        launcher.setSystemClassLoader(Maven32Main.class.getClassLoader());
+        launcher.setSystemClassLoader(Maven31Main.class.getClassLoader());
         launcher.configure(getClassWorldsConfStream());
     }
     

--- a/maven32-agent/src/main/java/jenkins/maven3/agent/Maven32Main.java
+++ b/maven32-agent/src/main/java/jenkins/maven3/agent/Maven32Main.java
@@ -85,7 +85,8 @@ public class Maven32Main
         main(m2Home, remotingJar, interceptorJar, interceptorCommonJar, null, tcpPort);
     }
 
-    private static void initializeLauncher() throws IOException, ConfigurationException, DuplicateRealmException {
+    private static void initializeLauncher()
+	    throws IOException, ConfigurationException, DuplicateRealmException, NoSuchRealmException {
         // load the default realms
         launcher = new Launcher();
         launcher.setSystemClassLoader(Maven32Main.class.getClassLoader());

--- a/maven32-agent/src/main/java/jenkins/maven3/agent/Maven32Main.java
+++ b/maven32-agent/src/main/java/jenkins/maven3/agent/Maven32Main.java
@@ -83,7 +83,7 @@ public class Maven32Main
         main(m2Home, remotingJar, interceptorJar, interceptorCommonJar, null, tcpPort);
     }
 
-    private static void initializeLauncher() {
+    private static void initializeLauncher() throws IOException {
         // load the default realms
         launcher = new Launcher();
         launcher.setSystemClassLoader(Maven32Main.class.getClassLoader());

--- a/maven32-agent/src/main/java/jenkins/maven3/agent/Maven32Main.java
+++ b/maven32-agent/src/main/java/jenkins/maven3/agent/Maven32Main.java
@@ -26,6 +26,7 @@ package jenkins.maven3.agent;
 import org.codehaus.plexus.classworlds.launcher.Launcher;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
+import org.codehaus.plexus.classworlds.realm.DuplicateRealmException;
 import org.codehaus.plexus.classworlds.launcher.ConfigurationException;
 
 import java.io.BufferedInputStream;
@@ -84,7 +85,7 @@ public class Maven32Main
         main(m2Home, remotingJar, interceptorJar, interceptorCommonJar, null, tcpPort);
     }
 
-    private static void initializeLauncher() throws IOException, ConfigurationException {
+    private static void initializeLauncher() throws IOException, ConfigurationException, DuplicateRealmException {
         // load the default realms
         launcher = new Launcher();
         launcher.setSystemClassLoader(Maven32Main.class.getClassLoader());

--- a/maven32-agent/src/main/java/jenkins/maven3/agent/Maven32Main.java
+++ b/maven32-agent/src/main/java/jenkins/maven3/agent/Maven32Main.java
@@ -26,6 +26,7 @@ package jenkins.maven3.agent;
 import org.codehaus.plexus.classworlds.launcher.Launcher;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
+import org.codehaus.plexus.classworlds.launcher.ConfigurationException;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -83,7 +84,7 @@ public class Maven32Main
         main(m2Home, remotingJar, interceptorJar, interceptorCommonJar, null, tcpPort);
     }
 
-    private static void initializeLauncher() throws IOException {
+    private static void initializeLauncher() throws IOException, ConfigurationException {
         // load the default realms
         launcher = new Launcher();
         launcher.setSystemClassLoader(Maven32Main.class.getClassLoader());

--- a/maven32-agent/src/main/java/jenkins/maven3/agent/Maven32Main.java
+++ b/maven32-agent/src/main/java/jenkins/maven3/agent/Maven32Main.java
@@ -83,7 +83,13 @@ public class Maven32Main
         main(m2Home, remotingJar, interceptorJar, interceptorCommonJar, null, tcpPort);
     }
 
-
+    private static void initializeLauncher() {
+        // load the default realms
+        launcher = new Launcher();
+        launcher.setSystemClassLoader(Maven32Main.class.getClassLoader());
+        launcher.configure(getClassWorldsConfStream());
+    }
+    
     /**
      *
      * @param m2Home
@@ -126,11 +132,7 @@ public class Maven32Main
         System.setProperty("maven3.interceptor", (interceptorJar != null ? interceptorJar
                 : interceptorJar).getPath());
 
-        // load the default realms
-        launcher = new Launcher();
-        launcher.setSystemClassLoader(Maven32Main.class.getClassLoader());
-        launcher.configure(getClassWorldsConfStream());
-
+        initializeLauncher();
 
         // create a realm for loading remoting subsystem.
         // this needs to be able to see maven.
@@ -183,7 +185,12 @@ public class Maven32Main
     public static int launch( String[] args ) throws Exception {
 
         try {
+            if (launcher == null) {
+                initializeLauncher();
+            }
+            
             launcher.launch( args );
+
         } catch ( Throwable e ) {
             e.printStackTrace();
             throw new Exception( e );

--- a/maven33-agent/src/main/java/jenkins/maven3/agent/Maven33Main.java
+++ b/maven33-agent/src/main/java/jenkins/maven3/agent/Maven33Main.java
@@ -79,7 +79,7 @@ public class Maven33Main
 	    throws IOException, ConfigurationException, DuplicateRealmException, NoSuchRealmException {
         // load the default realms
         launcher = new Launcher();
-        launcher.setSystemClassLoader(Maven32Main.class.getClassLoader());
+        launcher.setSystemClassLoader(Maven33Main.class.getClassLoader());
         launcher.configure(getClassWorldsConfStream());
     }
 


### PR DESCRIPTION
I believe I've discovered an issue; this could be because no one has used this feature before?
I enabled "Build Modules in Parallel" and my build failed consistently with the following output (including stack traces):

Established TCP socket on 51419
<===[JENKINS REMOTING CAPACITY]===>channel started
Executing Maven:  -N -B -f drive:\path\to\pom.xml clean install
java.lang.NullPointerException
	at jenkins.maven3.agent.Maven32Main.launch(Maven32Main.java:186)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:133)
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:68)
	at hudson.remoting.UserRequest.perform(UserRequest.java:153)
	at hudson.remoting.UserRequest.perform(UserRequest.java:50)
	at hudson.remoting.Request$2.run(Request.java:336)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Started by upstream project "InteropServer-3.0-build" build number 19
originally caused by:
 Started by user Jonathan Hyry
Finished: ABORTED
FATAL: java.lang.reflect.InvocationTargetException
java.io.IOException: java.lang.reflect.InvocationTargetException
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:173)
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:68)
	at hudson.remoting.UserRequest.perform(UserRequest.java:153)
	at hudson.remoting.UserRequest.perform(UserRequest.java:50)
	at hudson.remoting.Request$2.run(Request.java:336)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
	at ......remote call to Channel to Maven [C:\Program Files\Java\jdk1.8.0_112/bin/java, -Djava.awt.headless=true, -cp, C:\Program Files (x86)\Jenkins\plugins\maven-plugin\WEB-INF\lib\maven33-agent-1.8.1.jar;C:\Users\jhyry\Application\apache-maven-3.3.9\boot\plexus-classworlds-2.5.2.jar;C:\Users\jhyry\Application\apache-maven-3.3.9/conf/logging, jenkins.maven3.agent.Maven33Main, C:\Users\jhyry\Application\apache-maven-3.3.9, C:\Program Files (x86)\Jenkins\war\WEB-INF\lib\remoting-3.2.jar, C:\Program Files (x86)\Jenkins\plugins\maven-plugin\WEB-INF\lib\maven33-interceptor-1.8.1.jar, C:\Program Files (x86)\Jenkins\plugins\maven-plugin\WEB-INF\lib\maven3-interceptor-commons-1.8.1.jar, 51419](Native Method)
	at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1537)
	at hudson.remoting.UserResponse.retrieve(UserRequest.java:253)
	at hudson.remoting.Channel.call(Channel.java:822)
	at hudson.maven.ProcessCache$MavenProcess.call(ProcessCache.java:161)
	at hudson.maven.MavenBuild$MavenBuildExecution.doRun(MavenBuild.java:880)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:534)
	at hudson.model.Run.execute(Run.java:1729)
	at hudson.maven.MavenBuild.run(MavenBuild.java:270)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:404)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:133)
	at hudson.maven.Maven3Builder.call(Maven3Builder.java:68)
	at hudson.remoting.UserRequest.perform(UserRequest.java:153)
	at hudson.remoting.UserRequest.perform(UserRequest.java:50)
	at hudson.remoting.Request$2.run(Request.java:336)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.Exception: java.lang.NullPointerException
	at jenkins.maven3.agent.Maven32Main.launch(Maven32Main.java:189)
	... 14 more
Caused by: java.lang.NullPointerException
	at jenkins.maven3.agent.Maven32Main.launch(Maven32Main.java:186)
	... 14 more
channel stopped

The changes I'm proposing are just an idea about how to fix it.
I've never done development on Jenkins, Jenkins plugins, Maven, or any Maven plugins before, so I'm not intimately familiar with any additional initialization steps that might be required for Launcher.
From my perspective, this is a relatively simple issue with a simple fix.

Hopefully this helps.

Thanks,

Jon