### PR TITLE
[JENKINS-46053] - Remove Commons HttpClient 3.x from dependencies

### DIFF
--- a/maven-agent/pom.xml
+++ b/maven-agent/pom.xml
@@ -89,11 +89,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-    </dependency>    
-    <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
     </dependency>
     
     <!-- test dependencies -->

--- a/maven-interceptor/pom.xml
+++ b/maven-interceptor/pom.xml
@@ -51,12 +51,5 @@ THE SOFTWARE.
       <artifactId>classworlds</artifactId>
       <version>1.1</version>
     </dependency>
-   
-
-    <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Maven Plugin has already migrated to Apache HttpClient 4.x, so there is no transient usages. The Maven plugin **seems** to build fine, there are only few test timeouts on my machine.

https://issues.jenkins-ci.org/browse/JENKINS-46053

Upstream PR: https://github.com/jenkinsci/maven-plugin/pull/102

@reviewbybees