### PR TITLE
Init logging before the plexus container is created

### DIFF
--- a/maven3-interceptor-commons/src/main/java/org/apache/maven/cli/CommonCliRequest.java
+++ b/maven3-interceptor-commons/src/main/java/org/apache/maven/cli/CommonCliRequest.java
@@ -1,5 +1,6 @@
 package org.apache.maven.cli;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.cli.CommandLine;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequest;
@@ -9,10 +10,12 @@ import java.io.File;
 import java.util.Properties;
 
 /**
- * Copied from Maven {@code 3.5.4}. Older versions might not fill in all the fields.
+ * Copied from {@code org.apache.maven.cli.CliRequest} from Maven {@code 3.5.4}. Older versions might not fill in
+ * all the fields.
  */
 public class CommonCliRequest
 {
+    @SuppressFBWarnings({ "EI_EXPOSE_REP", "EI_EXPOSE_REP2" })
     String[] args;
 
     CommandLine commandLine;

--- a/maven3-interceptor-commons/src/main/java/org/apache/maven/cli/CommonCliRequest.java
+++ b/maven3-interceptor-commons/src/main/java/org/apache/maven/cli/CommonCliRequest.java
@@ -1,0 +1,104 @@
+package org.apache.maven.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.codehaus.plexus.classworlds.ClassWorld;
+
+import java.io.File;
+import java.util.Properties;
+
+/**
+ * Copied from Maven {@code 3.5.4}. Older versions might not fill in all the fields.
+ */
+public class CommonCliRequest
+{
+    String[] args;
+
+    CommandLine commandLine;
+
+    ClassWorld classWorld;
+
+    String workingDirectory;
+
+    File multiModuleProjectDirectory;
+
+    boolean debug;
+
+    boolean quiet;
+
+    boolean showErrors = true;
+
+    Properties userProperties = new Properties();
+
+    Properties systemProperties = new Properties();
+
+    MavenExecutionRequest request;
+
+    public CommonCliRequest( String[] args, ClassWorld classWorld )
+    {
+        this.args = args;
+        this.classWorld = classWorld;
+        this.request = new DefaultMavenExecutionRequest();
+    }
+
+    public String[] getArgs()
+    {
+        return args;
+    }
+
+    public CommandLine getCommandLine()
+    {
+        return commandLine;
+    }
+
+    public ClassWorld getClassWorld()
+    {
+        return classWorld;
+    }
+
+    public String getWorkingDirectory()
+    {
+        return workingDirectory;
+    }
+
+    public File getMultiModuleProjectDirectory()
+    {
+        return multiModuleProjectDirectory;
+    }
+
+    public boolean isDebug()
+    {
+        return debug;
+    }
+
+    public boolean isQuiet()
+    {
+        return quiet;
+    }
+
+    public boolean isShowErrors()
+    {
+        return showErrors;
+    }
+
+    public Properties getUserProperties()
+    {
+        return userProperties;
+    }
+
+    public Properties getSystemProperties()
+    {
+        return systemProperties;
+    }
+
+    public MavenExecutionRequest getRequest()
+    {
+        return request;
+    }
+
+    public void setUserProperties( Properties properties )
+    {
+        this.userProperties.putAll( properties );
+    }
+}

--- a/maven3-interceptor-commons/src/main/java/org/apache/maven/cli/MavenExecutionRequestBuilder.java
+++ b/maven3-interceptor-commons/src/main/java/org/apache/maven/cli/MavenExecutionRequestBuilder.java
@@ -33,4 +33,7 @@ public interface MavenExecutionRequestBuilder
 {
     MavenExecutionRequest getMavenExecutionRequest( String[] args, PrintStream printStream)
         throws MavenExecutionRequestPopulationException, SettingsBuildingException, MavenExecutionRequestsBuilderException;
+
+    MavenExecutionRequest getMavenExecutionRequest( CommonCliRequest commonCliRequest )
+        throws MavenExecutionRequestPopulationException, SettingsBuildingException, MavenExecutionRequestsBuilderException;
 }

--- a/maven3-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java
+++ b/maven3-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java
@@ -86,7 +86,7 @@ public class DefaultMavenExecutionRequestBuilder
     private PlexusContainer plexusContainer;
 
     private DefaultSecDispatcher dispatcher;
-    
+
     public void initialize()
         throws InitializationException
     {
@@ -100,10 +100,18 @@ public class DefaultMavenExecutionRequestBuilder
         }
     }
 
+    @Override
+    public MavenExecutionRequest getMavenExecutionRequest( CommonCliRequest commonCliRequest )
+        throws MavenExecutionRequestPopulationException, SettingsBuildingException, MavenExecutionRequestsBuilderException
+    {
+        throw new UnsupportedOperationException( "This method should not be called" );
+    }
+
     /**
-     * @throws MavenExecutionRequestPopulationException 
+     * @throws MavenExecutionRequestPopulationException
      * @see org.jvnet.hudson.maven3.MavenExecutionRequestBuilder.MavenExecutionRequestsBuilder#getMavenExecutionRequest(java.lang.String[])
      */
+    @Override
     public MavenExecutionRequest getMavenExecutionRequest( String[] args, PrintStream printStream )
         throws MavenExecutionRequestPopulationException, SettingsBuildingException,
         MavenExecutionRequestsBuilderException
@@ -124,7 +132,7 @@ public class DefaultMavenExecutionRequestBuilder
             encryption( cliRequest );
 
             MavenExecutionRequest request = executionRequestPopulator.populateDefaults( cliRequest.request );
-                        
+
             return request;
         }
         catch ( Exception e )
@@ -779,6 +787,6 @@ public class DefaultMavenExecutionRequestBuilder
             this.classWorld = classWorld;
             this.request = new DefaultMavenExecutionRequest();
         }
-    }    
-    
+    }
+
 }

--- a/maven31-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java
+++ b/maven31-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java
@@ -130,7 +130,7 @@ public class DefaultMavenExecutionRequestBuilder
     private EventSpyDispatcher eventSpyDispatcher;
 
     private static final String EXT_CLASS_PATH = "maven.ext.class.path";
-    
+
     static final String DEFAULT_BUILD_TIMESTAMP_FORMAT = "yyyyMMdd-HHmm";
 
     public void initialize()
@@ -151,9 +151,17 @@ public class DefaultMavenExecutionRequestBuilder
         }
     }
 
+    @Override
+    public MavenExecutionRequest getMavenExecutionRequest( CommonCliRequest commonCliRequest )
+        throws MavenExecutionRequestPopulationException, SettingsBuildingException, MavenExecutionRequestsBuilderException
+    {
+        throw new UnsupportedOperationException( "This method should not be called" );
+    }
+
     /**
-     * @throws MavenExecutionRequestPopulationException 
+     * @throws MavenExecutionRequestPopulationException
      */
+    @Override
     public MavenExecutionRequest getMavenExecutionRequest( String[] args, PrintStream printStream)
         throws MavenExecutionRequestPopulationException, SettingsBuildingException,
         MavenExecutionRequestsBuilderException
@@ -1147,5 +1155,5 @@ public class DefaultMavenExecutionRequestBuilder
     {
         return container.lookup( ModelProcessor.class );
     }
-    
+
 }

--- a/maven32-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java
+++ b/maven32-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java
@@ -116,7 +116,7 @@ public class DefaultMavenExecutionRequestBuilder
     private EventSpyDispatcher eventSpyDispatcher;
 
     private static final String EXT_CLASS_PATH = "maven.ext.class.path";
-    
+
     static final String DEFAULT_BUILD_TIMESTAMP_FORMAT = "yyyyMMdd-HHmm";
 
     public void initialize()
@@ -137,9 +137,17 @@ public class DefaultMavenExecutionRequestBuilder
         }
     }
 
+    @Override
+    public MavenExecutionRequest getMavenExecutionRequest( CommonCliRequest commonCliRequest )
+        throws MavenExecutionRequestPopulationException, SettingsBuildingException, MavenExecutionRequestsBuilderException
+    {
+        throw new UnsupportedOperationException( "This method should not be called" );
+    }
+
     /**
-     * @throws MavenExecutionRequestPopulationException 
+     * @throws MavenExecutionRequestPopulationException
      */
+    @Override
     public MavenExecutionRequest getMavenExecutionRequest( String[] args, PrintStream printStream)
         throws MavenExecutionRequestPopulationException, SettingsBuildingException,
         MavenExecutionRequestsBuilderException
@@ -1148,5 +1156,5 @@ public class DefaultMavenExecutionRequestBuilder
     {
         return container.lookup( ModelProcessor.class );
     }
-    
+
 }

--- a/maven33-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java
+++ b/maven33-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java
@@ -139,9 +139,17 @@ public class DefaultMavenExecutionRequestBuilder
         }
     }
 
+    @Override
+    public MavenExecutionRequest getMavenExecutionRequest( CommonCliRequest commonCliRequest )
+        throws MavenExecutionRequestPopulationException, SettingsBuildingException, MavenExecutionRequestsBuilderException
+    {
+        throw new UnsupportedOperationException( "This method should not be called" );
+    }
+
     /**
      * @throws MavenExecutionRequestPopulationException
      */
+    @Override
     public MavenExecutionRequest getMavenExecutionRequest( String[] args, PrintStream printStream)
         throws MavenExecutionRequestPopulationException, SettingsBuildingException,
         MavenExecutionRequestsBuilderException

--- a/maven35-interceptor/src/main/java/org/apache/maven/cli/CommonCliRequestFactory.java
+++ b/maven35-interceptor/src/main/java/org/apache/maven/cli/CommonCliRequestFactory.java
@@ -1,0 +1,286 @@
+package org.apache.maven.cli;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.ParseException;
+import org.apache.maven.cli.logging.Slf4jConfiguration;
+import org.apache.maven.cli.logging.Slf4jConfigurationFactory;
+import org.apache.maven.cli.logging.Slf4jLoggerManager;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.properties.internal.EnvironmentUtils;
+import org.codehaus.plexus.logging.LoggerManager;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Properties;
+
+public class CommonCliRequestFactory {
+
+    private ILoggerFactory slf4jLoggerFactory;
+
+    private LoggerManager plexusLoggerManager;
+
+    public CommonCliRequest create( String[] args ) throws MavenExecutionRequestsBuilderException {
+        try {
+            CommonCliRequest cliRequest = new CommonCliRequest( args, null );
+            initialize( cliRequest );
+            cli( cliRequest );
+            properties( cliRequest );
+            logging( cliRequest );
+            version( cliRequest );
+
+            return cliRequest;
+        } catch (Exception e) {
+            throw new MavenExecutionRequestsBuilderException( e.getMessage(), e );
+        }
+    }
+
+    public ILoggerFactory getSlf4jLoggerFactory() {
+        return slf4jLoggerFactory;
+    }
+
+    public LoggerManager getPlexusLoggerManager() {
+        return plexusLoggerManager;
+    }
+
+    private void initialize(CommonCliRequest cliRequest ) throws IOException {
+        if ( cliRequest.workingDirectory == null )
+        {
+            cliRequest.workingDirectory = System.getProperty( "user.dir" );
+        }
+
+        if ( cliRequest.multiModuleProjectDirectory == null )
+        {
+            File basedir = new File( "" );
+            try
+            {
+                cliRequest.multiModuleProjectDirectory = basedir.getCanonicalFile();
+            }
+            catch ( IOException e )
+            {
+                cliRequest.multiModuleProjectDirectory = basedir.getAbsoluteFile();
+            }
+        }
+
+        //
+        // Make sure the Maven home directory is an absolute path to save us from confusion with say drive-relative
+        // Windows paths.
+        //
+        String mavenHome = System.getProperty( "maven.home" );
+
+        if ( mavenHome != null )
+        {
+            System.setProperty( "maven.home", new File( mavenHome ).getAbsolutePath() );
+            String mavenConf = System.getProperty("maven.conf");
+            if (mavenConf == null) {
+                System.setProperty("maven.conf", new File(System.getProperty("maven.home", System.getProperty("user.dir", "")), "conf").getCanonicalPath());
+
+            }
+
+        }
+    }
+
+    private void cli( CommonCliRequest cliRequest )
+        throws Exception
+    {
+        //
+        // Parsing errors can happen during the processing of the arguments and we prefer not having to check if the logger is null
+        // and construct this so we can use an SLF4J logger everywhere.
+        //
+        // slf4jLogger = new Slf4jStdoutLogger();
+
+        CLIManager cliManager = new CLIManager();
+
+        try
+        {
+            cliRequest.commandLine = cliManager.parse( cliRequest.args );
+        }
+        catch ( ParseException e )
+        {
+            System.err.println( "Unable to parse command line options: " + e.getMessage() );
+            cliManager.displayHelp( System.out );
+            throw e;
+        }
+
+        if ( cliRequest.commandLine.hasOption( CLIManager.HELP ) )
+        {
+            cliManager.displayHelp( System.out );
+            throw new DefaultMavenExecutionRequestBuilder.ExitException( 0 );
+        }
+
+        if ( cliRequest.commandLine.hasOption( CLIManager.VERSION ) )
+        {
+            System.out.println( CLIReportingUtils.showVersion() );
+            throw new DefaultMavenExecutionRequestBuilder.ExitException( 0 );
+        }
+    }
+
+    private void properties( CommonCliRequest cliRequest )
+    {
+        populateProperties( cliRequest.commandLine, cliRequest.systemProperties, cliRequest.userProperties );
+    }
+
+    // ----------------------------------------------------------------------
+    // System properties handling
+    // ----------------------------------------------------------------------
+
+    static void populateProperties(CommandLine commandLine, Properties systemProperties, Properties userProperties )
+    {
+        EnvironmentUtils.addEnvVars( systemProperties );
+
+        // ----------------------------------------------------------------------
+        // Options that are set on the command line become system properties
+        // and therefore are set in the session properties. System properties
+        // are most dominant.
+        // ----------------------------------------------------------------------
+
+        if ( commandLine.hasOption( CLIManager.SET_SYSTEM_PROPERTY ) )
+        {
+            String[] defStrs = commandLine.getOptionValues( CLIManager.SET_SYSTEM_PROPERTY );
+
+            if ( defStrs != null )
+            {
+                for ( String defStr : defStrs )
+                {
+                    setCliProperty( defStr, userProperties );
+                }
+            }
+        }
+
+        systemProperties.putAll( System.getProperties() );
+
+        // ----------------------------------------------------------------------
+        // Properties containing info about the currently running version of Maven
+        // These override any corresponding properties set on the command line
+        // ----------------------------------------------------------------------
+
+        Properties buildProperties = CLIReportingUtils.getBuildProperties();
+
+        String mavenVersion = buildProperties.getProperty( CLIReportingUtils.BUILD_VERSION_PROPERTY );
+        systemProperties.setProperty( "maven.version", mavenVersion );
+
+        String mavenBuildVersion = CLIReportingUtils.createMavenVersionString( buildProperties );
+        systemProperties.setProperty( "maven.build.version", mavenBuildVersion );
+    }
+
+    private static void setCliProperty( String property, Properties properties )
+    {
+        String name;
+
+        String value;
+
+        int i = property.indexOf( "=" );
+
+        if ( i <= 0 )
+        {
+            name = property.trim();
+
+            value = "true";
+        }
+        else
+        {
+            name = property.substring( 0, i ).trim();
+
+            value = property.substring( i + 1 );
+        }
+
+        properties.setProperty( name, value );
+
+        // ----------------------------------------------------------------------
+        // I'm leaving the setting of system properties here as not to break
+        // the SystemPropertyProfileActivator. This won't harm embedding. jvz.
+        // ----------------------------------------------------------------------
+
+        System.setProperty( name, value );
+    }
+
+    /**
+     * configure logging
+     */
+    @SuppressFBWarnings({"DM_DEFAULT_ENCODING","URF_UNREAD_FIELD","PATH_TRAVERSAL_IN"})
+    private void logging( CommonCliRequest cliRequest )
+    {
+        cliRequest.debug = cliRequest.commandLine.hasOption( CLIManager.DEBUG );
+        cliRequest.quiet = !cliRequest.debug && cliRequest.commandLine.hasOption( CLIManager.QUIET );
+        cliRequest.showErrors = cliRequest.debug || cliRequest.commandLine.hasOption( CLIManager.ERRORS );
+
+        slf4jLoggerFactory = LoggerFactory.getILoggerFactory();
+        Slf4jConfiguration slf4jConfiguration = Slf4jConfigurationFactory.getConfiguration( slf4jLoggerFactory );
+
+        if ( cliRequest.debug )
+        {
+            cliRequest.request.setLoggingLevel( MavenExecutionRequest.LOGGING_LEVEL_DEBUG );
+            slf4jConfiguration.setRootLoggerLevel( Slf4jConfiguration.Level.DEBUG );
+        }
+        else if ( cliRequest.quiet )
+        {
+            cliRequest.request.setLoggingLevel( MavenExecutionRequest.LOGGING_LEVEL_ERROR );
+            slf4jConfiguration.setRootLoggerLevel( Slf4jConfiguration.Level.ERROR );
+        }
+        else
+        {
+            cliRequest.request.setLoggingLevel( MavenExecutionRequest.LOGGING_LEVEL_INFO );
+            slf4jConfiguration.setRootLoggerLevel( Slf4jConfiguration.Level.INFO );
+        }
+
+        if ( cliRequest.commandLine.hasOption( CLIManager.LOG_FILE ) )
+        {
+            File logFile = new File( cliRequest.commandLine.getOptionValue( CLIManager.LOG_FILE ) );
+            logFile = resolveFile( logFile, cliRequest.workingDirectory );
+
+            // redirect stdout and stderr to file
+            try
+            {
+                PrintStream ps = new PrintStream( new FileOutputStream( logFile ) );
+                System.setOut( ps );
+                System.setErr( ps );
+            }
+            catch ( FileNotFoundException e )
+            {
+                //
+                // Ignore
+                //
+            }
+        }
+
+        slf4jConfiguration.activate();
+
+        plexusLoggerManager = new Slf4jLoggerManager();
+        // slf4jLogger = slf4jLoggerFactory.getLogger( this.getClass().getName() );
+    }
+
+    @SuppressFBWarnings({"PATH_TRAVERSAL_IN"})
+    static File resolveFile( File file, String workingDirectory )
+    {
+        if ( file == null )
+        {
+            return null;
+        }
+        else if ( file.isAbsolute() )
+        {
+            return file;
+        }
+        else if ( file.getPath().startsWith( File.separator ) )
+        {
+            // drive-relative Windows path
+            return file.getAbsoluteFile();
+        }
+        else
+        {
+            return new File( workingDirectory, file.getPath() ).getAbsoluteFile();
+        }
+    }
+
+    private void version( CommonCliRequest cliRequest )
+    {
+        if ( cliRequest.debug || cliRequest.commandLine.hasOption( CLIManager.SHOW_VERSION ) )
+        {
+            System.out.println( CLIReportingUtils.showVersion() );
+        }
+    }
+}

--- a/maven35-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java
+++ b/maven35-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java
@@ -23,7 +23,6 @@ package org.apache.maven.cli;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.ParseException;
 import org.apache.maven.InternalErrorException;
 import org.apache.maven.building.FileSource;
 import org.apache.maven.building.Source;
@@ -31,10 +30,6 @@ import org.apache.maven.cli.configuration.ConfigurationProcessor;
 import org.apache.maven.cli.configuration.SettingsXmlConfigurationProcessor;
 import org.apache.maven.cli.event.DefaultEventSpyContext;
 import org.apache.maven.cli.event.ExecutionEventLogger;
-import org.apache.maven.cli.logging.Slf4jConfiguration;
-import org.apache.maven.cli.logging.Slf4jConfigurationFactory;
-import org.apache.maven.cli.logging.Slf4jLoggerManager;
-import org.apache.maven.cli.logging.Slf4jStdoutLogger;
 import org.apache.maven.cli.transfer.ConsoleMavenTransferListener;
 import org.apache.maven.cli.transfer.QuietMavenTransferListener;
 import org.apache.maven.cli.transfer.Slf4jMavenTransferListener;
@@ -45,8 +40,13 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequestPopulationException;
 import org.apache.maven.execution.MavenExecutionRequestPopulator;
 import org.apache.maven.model.building.ModelProcessor;
-import org.apache.maven.properties.internal.EnvironmentUtils;
-import org.apache.maven.settings.building.*;
+import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
+import org.apache.maven.settings.building.SettingsBuilder;
+import org.apache.maven.settings.building.SettingsBuildingException;
+import org.apache.maven.settings.building.SettingsBuildingRequest;
+import org.apache.maven.settings.building.SettingsBuildingResult;
+import org.apache.maven.settings.building.SettingsProblem;
+import org.apache.maven.settings.building.SettingsSource;
 import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.apache.maven.toolchain.building.DefaultToolchainsBuildingRequest;
 import org.apache.maven.toolchain.building.ToolchainsBuilder;
@@ -57,14 +57,12 @@ import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
-import org.codehaus.plexus.logging.LoggerManager;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.transfer.TransferListener;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonatype.plexus.components.cipher.DefaultPlexusCipher;
 import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
@@ -73,10 +71,11 @@ import org.sonatype.plexus.components.sec.dispatcher.model.SettingsSecurity;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.PrintStream;
-import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
 
 /**
  * Most of code is coming from asf svn repo waiting before having available
@@ -95,9 +94,6 @@ public class DefaultMavenExecutionRequestBuilder
     private MavenExecutionRequestPopulator executionRequestPopulator;
 
     @Requirement
-    private Logger plexusLogger;
-
-    @Requirement
     private ModelProcessor modelProcessor;
 
     @Requirement
@@ -107,11 +103,7 @@ public class DefaultMavenExecutionRequestBuilder
 
     private Map<String, ConfigurationProcessor> configurationProcessors;
 
-    private LoggerManager plexusLoggerManager;
-
     private Logger slf4jLogger;
-
-    private ILoggerFactory slf4jLoggerFactory;
 
     private EventSpyDispatcher eventSpyDispatcher;
 
@@ -133,6 +125,7 @@ public class DefaultMavenExecutionRequestBuilder
             settingsBuilder = plexusContainer.lookup( SettingsBuilder.class );
             toolchainsBuilder = plexusContainer.lookup( ToolchainsBuilder.class );
             configurationProcessors = plexusContainer.lookupMap( ConfigurationProcessor.class );
+            slf4jLogger = plexusContainer.lookup( ILoggerFactory.class ).getLogger( this.getClass().getName() );
         }
         catch ( ComponentLookupException e )
         {
@@ -140,21 +133,14 @@ public class DefaultMavenExecutionRequestBuilder
         }
     }
 
-    /**
-     * @throws MavenExecutionRequestPopulationException
-     */
-    public MavenExecutionRequest getMavenExecutionRequest( String[] args, PrintStream printStream)
-        throws MavenExecutionRequestPopulationException, SettingsBuildingException,
-        MavenExecutionRequestsBuilderException
-    {
+    @Override
+    public MavenExecutionRequest getMavenExecutionRequest( CommonCliRequest commonCliRequest )
+        throws MavenExecutionRequestPopulationException, SettingsBuildingException, MavenExecutionRequestsBuilderException {
+
         try
         {
-            CliRequest cliRequest = new CliRequest( args, null );
-            initialize( cliRequest );
-            cli( cliRequest );
-            properties( cliRequest );
-            logging( cliRequest );
-            version( cliRequest );
+            CliRequest cliRequest = toCliRequest( commonCliRequest );
+
             // we are in a container so no need
             //localContainer = container( cliRequest );
 
@@ -181,143 +167,32 @@ public class DefaultMavenExecutionRequestBuilder
         {
             throw new MavenExecutionRequestsBuilderException( e.getMessage(), e );
         }
-
     }
 
+    private CliRequest toCliRequest( CommonCliRequest commonCliRequest ) {
+        CliRequest cliRequest = new CliRequest( commonCliRequest.args, null );
 
-    private void initialize( CliRequest cliRequest ) throws IOException {
-        if ( cliRequest.workingDirectory == null )
-        {
-            cliRequest.workingDirectory = System.getProperty( "user.dir" );
-        }
+        cliRequest.commandLine = commonCliRequest.commandLine;
+        cliRequest.classWorld = commonCliRequest.classWorld;
+        cliRequest.workingDirectory = commonCliRequest.workingDirectory;
+        cliRequest.multiModuleProjectDirectory = commonCliRequest.multiModuleProjectDirectory;
+        cliRequest.debug = commonCliRequest.debug;
+        cliRequest.quiet = commonCliRequest.quiet;
+        cliRequest.showErrors = commonCliRequest.showErrors;
+        cliRequest.userProperties = commonCliRequest.userProperties;
+        cliRequest.systemProperties = commonCliRequest.systemProperties;
+        cliRequest.request = commonCliRequest.request;
 
-        if ( cliRequest.multiModuleProjectDirectory == null )
-        {
-            File basedir = new File( "" );
-            try
-            {
-                cliRequest.multiModuleProjectDirectory = basedir.getCanonicalFile();
-            }
-            catch ( IOException e )
-            {
-                cliRequest.multiModuleProjectDirectory = basedir.getAbsoluteFile();
-            }
-        }
-
-        //
-        // Make sure the Maven home directory is an absolute path to save us from confusion with say drive-relative
-        // Windows paths.
-        //
-        String mavenHome = System.getProperty( "maven.home" );
-
-        if ( mavenHome != null )
-        {
-            System.setProperty( "maven.home", new File( mavenHome ).getAbsolutePath() );
-            String mavenConf = System.getProperty("maven.conf");
-            if (mavenConf == null) {
-                System.setProperty("maven.conf", new File(System.getProperty("maven.home", System.getProperty("user.dir", "")), "conf").getCanonicalPath());
-
-            }
-
-        }
-    }
-
-    private void cli( CliRequest cliRequest )
-            throws Exception
-    {
-        //
-        // Parsing errors can happen during the processing of the arguments and we prefer not having to check if the logger is null
-        // and construct this so we can use an SLF4J logger everywhere.
-        //
-        slf4jLogger = new Slf4jStdoutLogger();
-
-        CLIManager cliManager = new CLIManager();
-
-        try
-        {
-            cliRequest.commandLine = cliManager.parse( cliRequest.args );
-        }
-        catch ( ParseException e )
-        {
-            System.err.println( "Unable to parse command line options: " + e.getMessage() );
-            cliManager.displayHelp( System.out );
-            throw e;
-        }
-
-        if ( cliRequest.commandLine.hasOption( CLIManager.HELP ) )
-        {
-            cliManager.displayHelp( System.out );
-            throw new ExitException( 0 );
-        }
-
-        if ( cliRequest.commandLine.hasOption( CLIManager.VERSION ) )
-        {
-            System.out.println( CLIReportingUtils.showVersion() );
-            throw new ExitException( 0 );
-        }
+        return cliRequest;
     }
 
     /**
-     * configure logging
+     * @throws MavenExecutionRequestPopulationException
      */
-    @SuppressFBWarnings({"DM_DEFAULT_ENCODING","URF_UNREAD_FIELD","PATH_TRAVERSAL_IN"})
-    private void logging( CliRequest cliRequest )
+    public MavenExecutionRequest getMavenExecutionRequest( String[] args, PrintStream printStream)
+        throws MavenExecutionRequestPopulationException, SettingsBuildingException, MavenExecutionRequestsBuilderException
     {
-        cliRequest.debug = cliRequest.commandLine.hasOption( CLIManager.DEBUG );
-        cliRequest.quiet = !cliRequest.debug && cliRequest.commandLine.hasOption( CLIManager.QUIET );
-        cliRequest.showErrors = cliRequest.debug || cliRequest.commandLine.hasOption( CLIManager.ERRORS );
-
-        slf4jLoggerFactory = LoggerFactory.getILoggerFactory();
-        Slf4jConfiguration slf4jConfiguration = Slf4jConfigurationFactory.getConfiguration( slf4jLoggerFactory );
-
-        if ( cliRequest.debug )
-        {
-            cliRequest.request.setLoggingLevel( MavenExecutionRequest.LOGGING_LEVEL_DEBUG );
-            slf4jConfiguration.setRootLoggerLevel( Slf4jConfiguration.Level.DEBUG );
-        }
-        else if ( cliRequest.quiet )
-        {
-            cliRequest.request.setLoggingLevel( MavenExecutionRequest.LOGGING_LEVEL_ERROR );
-            slf4jConfiguration.setRootLoggerLevel( Slf4jConfiguration.Level.ERROR );
-        }
-        else
-        {
-            cliRequest.request.setLoggingLevel( MavenExecutionRequest.LOGGING_LEVEL_INFO );
-            slf4jConfiguration.setRootLoggerLevel( Slf4jConfiguration.Level.INFO );
-        }
-
-        if ( cliRequest.commandLine.hasOption( CLIManager.LOG_FILE ) )
-        {
-            File logFile = new File( cliRequest.commandLine.getOptionValue( CLIManager.LOG_FILE ) );
-            logFile = resolveFile( logFile, cliRequest.workingDirectory );
-
-            // redirect stdout and stderr to file
-            try
-            {
-                PrintStream ps = new PrintStream( new FileOutputStream( logFile ) );
-                System.setOut( ps );
-                System.setErr( ps );
-            }
-            catch ( FileNotFoundException e )
-            {
-                //
-                // Ignore
-                //
-            }
-        }
-
-        slf4jConfiguration.activate();
-
-        plexusLoggerManager = new Slf4jLoggerManager();
-        slf4jLogger = slf4jLoggerFactory.getLogger( this.getClass().getName() );
-    }
-
-    private void version( CliRequest cliRequest )
-    {
-        if ( cliRequest.debug || cliRequest.commandLine.hasOption( CLIManager.SHOW_VERSION ) )
-        {
-            System.out.println( CLIReportingUtils.showVersion() );
-        }
+        throw new UnsupportedOperationException( "This method should not be called" );
     }
 
     private void commands( CliRequest cliRequest )
@@ -337,10 +212,6 @@ public class DefaultMavenExecutionRequestBuilder
         }
     }
 
-    private void properties( CliRequest cliRequest )
-    {
-        populateProperties( cliRequest.commandLine, cliRequest.systemProperties, cliRequest.userProperties );
-    }
     /**
     private PlexusContainer container( CliRequest cliRequest )
         throws Exception
@@ -1142,80 +1013,6 @@ public class DefaultMavenExecutionRequestBuilder
         {
             return new File( workingDirectory, file.getPath() ).getAbsoluteFile();
         }
-    }
-
-    // ----------------------------------------------------------------------
-    // System properties handling
-    // ----------------------------------------------------------------------
-
-    static void populateProperties( CommandLine commandLine, Properties systemProperties, Properties userProperties )
-    {
-        EnvironmentUtils.addEnvVars( systemProperties );
-
-        // ----------------------------------------------------------------------
-        // Options that are set on the command line become system properties
-        // and therefore are set in the session properties. System properties
-        // are most dominant.
-        // ----------------------------------------------------------------------
-
-        if ( commandLine.hasOption( CLIManager.SET_SYSTEM_PROPERTY ) )
-        {
-            String[] defStrs = commandLine.getOptionValues( CLIManager.SET_SYSTEM_PROPERTY );
-
-            if ( defStrs != null )
-            {
-                for ( String defStr : defStrs )
-                {
-                    setCliProperty( defStr, userProperties );
-                }
-            }
-        }
-
-        systemProperties.putAll( System.getProperties() );
-
-        // ----------------------------------------------------------------------
-        // Properties containing info about the currently running version of Maven
-        // These override any corresponding properties set on the command line
-        // ----------------------------------------------------------------------
-
-        Properties buildProperties = CLIReportingUtils.getBuildProperties();
-
-        String mavenVersion = buildProperties.getProperty( CLIReportingUtils.BUILD_VERSION_PROPERTY );
-        systemProperties.setProperty( "maven.version", mavenVersion );
-
-        String mavenBuildVersion = CLIReportingUtils.createMavenVersionString( buildProperties );
-        systemProperties.setProperty( "maven.build.version", mavenBuildVersion );
-    }
-
-    private static void setCliProperty( String property, Properties properties )
-    {
-        String name;
-
-        String value;
-
-        int i = property.indexOf( "=" );
-
-        if ( i <= 0 )
-        {
-            name = property.trim();
-
-            value = "true";
-        }
-        else
-        {
-            name = property.substring( 0, i ).trim();
-
-            value = property.substring( i + 1 );
-        }
-
-        properties.setProperty( name, value );
-
-        // ----------------------------------------------------------------------
-        // I'm leaving the setting of system properties here as not to break
-        // the SystemPropertyProfileActivator. This won't harm embedding. jvz.
-        // ----------------------------------------------------------------------
-
-        System.setProperty( name, value );
     }
 
     static class ExitException

--- a/maven35-interceptor/src/main/java/org/jvnet/hudson/maven3/launcher/Maven35Launcher.java
+++ b/maven35-interceptor/src/main/java/org/jvnet/hudson/maven3/launcher/Maven35Launcher.java
@@ -106,7 +106,7 @@ public class Maven35Launcher
             CommonCliRequestFactory commonCliRequestFactory = new CommonCliRequestFactory();
             CommonCliRequest commonCliRequest = commonCliRequestFactory.create( args );
 
-            DefaultPlexusContainer container = new DefaultPlexusContainer(cc, new AbstractModule() {
+            DefaultPlexusContainer container = new DefaultPlexusContainer( cc, new AbstractModule() {
 
                 @Override
                 protected void configure() {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
## Problem description
Some `DEBUG` logs are missing from the build logs when using maven extensions with [maven-plugin](https://github.com/jenkinsci/maven-plugin).

## How to reproduce?
To reproduce the issue I've created a small [project](https://github.com/c00ler/sample-project-with-extension), that consists of two parts. An [extension](https://github.com/c00ler/sample-project-with-extension/tree/main/simple-extension), that includes `AbstractMavenLifecycleParticipant` and an `EventSpy`. A simple [project](https://github.com/c00ler/sample-project-with-extension/tree/main/simple-project), configured to use the above extension. I created two builds on a local Jenkins instance. One is using the `Freestyle` job type and the other one is using `Maven project` job type (provided by `maven-plugin`). Both builds are configured in the same way. First, as a pre-build step, the extension is being built and installed in the local repository using `clean install` goals and specifying the pom `simple-extension/pom.xml`. Second, the simple project is being built, using `clean install -X` and specifying the pom `simple-project/pom.xml`.

Jenkins environment:
- Java 11
- Jenkins version: **2.332.1**. The minimum version required by `maven-plugin`
- `maven-interceptors version`: locally built from `master` with the changes from this PR
- `maven-plugin version`: locally built from `master` with the only change to use the local version of `maven-interceptors`
- Maven version: `3.8.3`

Since the `Freestyle` job is invoking maven directly, its result was taken as a baseline. When running the `Freestyle` job, among other outputs I can see the logging messages produced by my extension. On both levels, info and debug, from both leggers, slf4j, and plexus:
   
![Screenshot 2022-09-26 at 12 06 46](https://user-images.githubusercontent.com/1210272/192250270-8fdd89ec-0f59-49ae-b76b-4f9d262c6709.png)

![Screenshot 2022-09-26 at 12 04 53](https://user-images.githubusercontent.com/1210272/192249942-755226be-de03-4e3e-92ad-c154baed9f92.png)

Since the only way to use maven extensions with `maven-plugin` is via `PlexusModuleContributorFactory`, I've created a simple contributor that adds an extension from my local maven repository (installed in the pre-build step) into the build.

When running `Maven project` job without the changes from this PR (`maven-interceptors` are built from `master`) I can only see the following logs:

![Screenshot 2022-09-26 at 12 20 22](https://user-images.githubusercontent.com/1210272/192253247-3ea955b8-d0e7-4cda-99a6-82eea863507b.png)

![Screenshot 2022-09-26 at 12 20 49](https://user-images.githubusercontent.com/1210272/192253262-ab47902e-9248-408e-a3da-263291efd8b5.png)

There are no debug logs from the `EventSpy`. Also, the produced output doesn't include other debug logs.

## Solution description
After comparing [MavenCli](https://github.com/apache/maven/blob/maven-3.5.4/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java#L271) with [DefaultMavenExecutionRequestBuilder](https://github.com/jenkinsci/maven-interceptors/blob/master/maven35-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java#L146), I've noticed that there is a difference in the way the plexus container is created. In Maven code the [container](https://github.com/apache/maven/blob/1edded0938998edf8bf061f1ceb3cfdeccf443fe/maven-embedder/src/main/java/org/apache/maven/cli/MavenCli.java#L635) is created after the cli parameters are already parsed, and the logger has been configured accordingly. In the interceptor code the [container](https://github.com/jenkinsci/maven-interceptors/blob/master/maven35-interceptor/src/main/java/org/jvnet/hudson/maven3/launcher/Maven35Launcher.java#L103) is created very early before the cli parameters are parsed. Therefore `Slf4jLoggerManager` is created using default settings. Also, the container doesn't have a binding for the `ILoggerFactory`.

I tried multiple ways to update `Slf4jLoggerManager` and add missing binding from the [point](https://github.com/jenkinsci/maven-interceptors/blob/master/maven35-interceptor/src/main/java/org/apache/maven/cli/DefaultMavenExecutionRequestBuilder.java#L158) where the cli arguments are already parsed, but none of them worked. I believe it's due to the fact that at this moment loggers were already eagerly created and the injection has happened to the classes that require them. I was considering two options to solve this problem. The first one was to duplicate cli parsing before the container is created. The second one is to move the `CliRequest` initialization methods, which happen before the container is created in the original Maven code, from `DefaultMavenExecutionRequestBuilder` to `Maven35Launcher`, so they are executed before the plexus container is created. I choose to implement the latter approach because it doesn't require double parsing of the cli parameters, and it keeps the initialization steps in the same order as they happen in the original Maven code.

To implement the described approach I had to change the `MavenExecutionRequestBuilder` interface to have another method that accepts `CommonCliRequest`. A new method allows changing only some interceptors, while others can keep using the old logic. `CommonCliRequest` is a copy of the original `org.apache.maven.cli.CliRequest` taken from the most recent, supported version of Maven (3.5.4). It is needed because `CliRequest` can evolve over time, and new properties might be added. Since it's a part of a public interface it has to include all the properties from the recent versions. `CommonCliRequest` is partially initialized in the `CommonCliRequestFactory` via calling all the methods that are happening before the plexus container is created (methods copied as-is from `DefaultMavenExecutionRequestBuilder` of the respective interceptor). After that, the plexus container is created with the initialized logging. And `CommonCliRequest` is passed to the `MavenExecutionRequestBuilder` to perform the rest of the initialization. I've only modified the interceptor used for Maven 3.5, the rest of the interceptors are left untouched. 

When running `Maven project` job with the described changes (`maven-interceptors` are built from the branch) I can see all the debug logs:

![Screenshot 2022-09-26 at 13 10 45](https://user-images.githubusercontent.com/1210272/192262231-a99d15f2-382b-4016-a897-65baad8dff27.png)

![Screenshot 2022-09-26 at 13 11 02](https://user-images.githubusercontent.com/1210272/192262251-98c21397-4192-46c4-bf58-299e1fa7e5f0.png)

The other debug logs, that were absent before, are also now present.

## Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
