### PR TITLE
Update junit and maven-core to suggested Dependabot versions, fix release-drafter config.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,6 @@
 _extends: .github
 tag-template: maven-modules-$NEXT_MINOR_VERSION
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/maven35-agent/pom.xml
+++ b/maven35-agent/pom.xml
@@ -57,7 +57,7 @@
       <!-- TODO: Actually smells like a bug in Maven Embedder -->
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.5.4</version>
+      <version>3.8.1</version>
     </dependency>
     <dependency>
       <!-- TODO: Actually smells like a bug in Maven Embedder -->

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.2</version>
+        <version>4.13.1</version>
       </dependency>  
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Dependabot recommended upgrading these packages: junit and maven-core
I merged the automatic commits, rebuilt, and the build/tests/packaging ran clean.
Attached is the build log.
[build.log](https://github.com/jenkinsci/maven-interceptors/files/14734913/build.log)

Also, there was a missing configuration item for the release-drafter workflow, I
 went ahead and added a very basic release draft template to allow the workflow
 to run without failing on an invalid configuration error.

There appear to be no issues or PRs related to these things.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
